### PR TITLE
Fix: fix readme for assets precompile

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ bundle install
 bundle exec rails db:create
 bundle exec rails db:migrate
 bundle exec rails db:seed
+bundle exec rake assets:precompile
 ```
 
 ### Running the project


### PR DESCRIPTION
tailwind compile error can be fixed by this command. `bundle exec rake assets:precompile`